### PR TITLE
Make the scheme shared for Carthage compatibility

### DIFF
--- a/CommonCryptoModule.xcodeproj/xcshareddata/xcschemes/CommonCryptoModule.xcscheme
+++ b/CommonCryptoModule.xcodeproj/xcshareddata/xcschemes/CommonCryptoModule.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8317094E1FAB663200D42715"
+               BuildableName = "CommonCryptoModule.framework"
+               BlueprintName = "CommonCryptoModule"
+               ReferencedContainer = "container:CommonCryptoModule.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8317094E1FAB663200D42715"
+            BuildableName = "CommonCryptoModule.framework"
+            BlueprintName = "CommonCryptoModule"
+            ReferencedContainer = "container:CommonCryptoModule.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8317094E1FAB663200D42715"
+            BuildableName = "CommonCryptoModule.framework"
+            BlueprintName = "CommonCryptoModule"
+            ReferencedContainer = "container:CommonCryptoModule.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
# Reason for this pull request

[Carthage](https://github.com/Carthage/Carthage) is a popular alternative to Cocoapods. In order to make a framework compatible with Carthage, the schema of the framework target needs to be shared. 

For `CommonCryptoModule`, this is all that is needed to make this repository Carthage-compatible, it will work out of the box.

# Changes
Shared the framework scheme. This looks like a lot of XML magic, but in reality I just opened XCode and selected the "shared" checkbox in the scheme management.